### PR TITLE
fix: state initialize에서 graph meta를 더미로 사용하는 문제 해결

### DIFF
--- a/core/agents/paper_concept_alignment_agent.py
+++ b/core/agents/paper_concept_alignment_agent.py
@@ -48,7 +48,7 @@ class PaperConceptAlignmentAgent:
         print(f"📊 전체 커리큘럼: 노드 {len(nodes)}개, 엣지 {len(edges)}개")
 
         # 논문 본문 생성
-        paper_body_summary = self._format_paper_body(paper_info)
+        paper_body_summary = curriculum["graph_meta"]["summarize"]
 
         # 전체 커리큘럼 구조 포맷팅
         curriculum_nodes = self._format_all_nodes(nodes)

--- a/core/graphs/parallel/graph_parallel.py
+++ b/core/graphs/parallel/graph_parallel.py
@@ -21,28 +21,21 @@ from core.graphs.parallel.state_parallel import CreateCurriculumOverallState
 def create_initial_state(
     subgraph_data: Dict[str, Any],
     user_info_data: Dict[str, Any],
-    paper_raw_data: Dict[str, Any]
+    paper_raw_data: Dict[str, Any],
+    paper_meta_data: Dict[str,Any]
 ) -> CreateCurriculumOverallState:
     """
     데이터를 입력받아 Transform을 수행
     LangGraph 실행을 위한 Initial State를 생성하여 반환
     """
-    
-    
-    meta_data_input = {
-        "paper_id": paper_raw_data.get("paper_id", "Unknown ID"), 
-        "title" : paper_raw_data.get("title", "Unknown Title"),
-        "summarize": paper_raw_data.get("abstract", "") # Use abstract as summary for now
-    }
-
     # Subgraph -> Curriculum 변환 (Transform)
-    curriculum_data = transform_subgraph_to_final_curriculum(subgraph_data, meta_data_input)
+    curriculum_data = transform_subgraph_to_final_curriculum(subgraph_data, paper_meta_data)
 
     # Initial State 
     initial_state = {
         "paper_name": paper_raw_data.get("title", "Unknown"),
-        "paper_summary": paper_raw_data.get("abstract", ""),
-        "initial_keywords": [n.get("keyword") for n in curriculum_data.get("nodes", [])],
+        "paper_summary": paper_meta_data.get("summarize", ""),
+        "initial_keywords": [n.get("keyword") for n in curriculum_data.get("nodes", [])],  # 여기 지금 initial keywords가 받아온게 들어오고 있지않아서 추가적으로 인자로 받아서 넣어줘야할 것 같습니다
         "paper_content": paper_raw_data,
         "user_info": user_info_data,
         "curriculum": curriculum_data,

--- a/core/prompts/paper_concept_alignment/v1.py
+++ b/core/prompts/paper_concept_alignment/v1.py
@@ -23,7 +23,7 @@ PAPER_CONCEPT_ALIGNMENT_PROMPT_V1 = ChatPromptTemplate.from_messages([
 - 제목: {paper_title}
 - 초록: {paper_abstract}
 
-[논문 본문]
+[논문 요약]
 {paper_body_summary}
 
 [학습 커리큘럼 구조]

--- a/core/tests/parallel_graphs_test.py
+++ b/core/tests/parallel_graphs_test.py
@@ -11,9 +11,10 @@ async def main():
 
     # dummy 데이터 경로 설정
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    user_info_path = os.path.join(current_dir, "../../dummy_data/dummy_user_information_known.json")
+    user_info_path = os.path.join(current_dir, "../../dummy_data/dummy_user_information.json")
     paper_content_path = os.path.join(current_dir, "../../dummy_data/dummy_parsing_paper.json")
-    subgraph_path = os.path.join(current_dir, "../../dummy_data/dummy_subgraph_known.json")
+    subgraph_path = os.path.join(current_dir, "../../dummy_data/dummy_subgraph.json")
+    meta_path = os.path.join(current_dir, "../../dummy_data/dummy_meta_data_attention.json")
     
     
     
@@ -25,6 +26,8 @@ async def main():
             user_info_data = json.load(f)
         with open(paper_content_path, "r", encoding="utf-8") as f:
             paper_raw_data = json.load(f)
+        with open(meta_path, "r", encoding="utf-8") as f:
+            paper_meta_data = json.load(f)
     except FileNotFoundError as e:
         print(f"❌ 파일을 찾을 수 없습니다: {e}")
         return
@@ -33,7 +36,8 @@ async def main():
     initial_state = create_initial_state(
         subgraph_data=dummy_subgraph,
         user_info_data=user_info_data,
-        paper_raw_data=paper_raw_data
+        paper_raw_data=paper_raw_data,
+        paper_meta_data=paper_meta_data
     )
 
     app = run_langgraph_workflow()


### PR DESCRIPTION
## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용

- [ ] state initialize에서 graph meta를 더미로 사용하는 문제 해결


## 💬 리뷰 요구사항 or 추가 코멘트(선택)
> - graph_parallel.py 에서 38라인 ("initial_keywords": [n.get("keyword") for n in curriculum_data.get("nodes", [])]) 여기 initial keywords 받아온 거 쓸 수 있도록 수정 필요합니다. 
> - create_initial_state에 인자 추가했습니다.
