### PR TITLE
[#62] fix: 존재하지 않는 id값이 최종 sub-graph에 포함되는 문제 해결

### DIFF
--- a/core/agents/keyword_graph_agent.py
+++ b/core/agents/keyword_graph_agent.py
@@ -137,6 +137,7 @@ class KeywordGraphAgent:
         subgraph = transform_graph_data(self.init_subgraph, agent_output, keyword_name_to_property, paper_id)
 
         # 3. Agent의 출력 Keyword의 GraphDB 상 name, alias 뽑기
+        valid_keywords = set([keyword['keyword'] for keyword in subgraph['nodes']])
         all_keyword_alias = {}
         for db_keyword in self.init_subgraph['graph']['nodes']['keywords']:
             if db_keyword['name'] in valid_keywords:
@@ -173,5 +174,16 @@ class KeywordGraphAgent:
         # 5. Subgraph Keyword 이름 수정
         for nodes in subgraph['nodes']:
             nodes['keyword'] = nodes['keyword'].split("(")[0].strip().title()
+
+        # 6. 없는 Node를 참조하고 있는 모든 Edge 삭제
+        valid_ids = [subgraph['paper_id']] + [keyword['keyword_id'] for keyword in subgraph['nodes'] if keyword['keyword_id']]
+        for edge in subgraph['edges']:
+            start_id = edge['start']
+            end_id = edge['end']
+
+            if start_id in valid_ids and end_id in valid_ids:
+                continue
+            else:
+                subgraph['edges'].remove(edge)
 
         return subgraph

--- a/core/tests/test_keyword_graph_agent.py
+++ b/core/tests/test_keyword_graph_agent.py
@@ -34,7 +34,7 @@ async def main():
     # 4. Agent 실행
     ## 테스트 데이터 로드
     data_dir = project_root / "dummy_data"
-    paper_path = data_dir / "dummy_parsing_paper.json"
+    paper_path = data_dir / "dummy_parsing_paper_BERT.json"
     user_info_path = data_dir / "dummy_user_information.json"
     
     try:
@@ -54,14 +54,11 @@ async def main():
     test_input: KeywordGraphInput = {
         "paper_info": paper_info,
         "user_info": user_info,
-        "initial_keyword": [
-                            "Self-Attention Mechanism",
-                            "Scaled Dot-Product Attention",
-                            "Multi-Head Attention",
-                            "Position-wise Feed-Forward Networks",
-                            "Positional Encoding",
-                            "Residual Connections and Layer Normalization"
-                            ] # 일단 임의로 설정
+        "initial_keyword": ["Bidirectional Encoder Representations",
+                            "Masked Language Model",
+                            "Next Sentence Prediction",
+                            "Transformer",
+                            "Fine-tuning"] # 일단 임의로 설정
     }
     result = await agent.run(test_input)
 


### PR DESCRIPTION
# [#62] fix: 존재하지 않는 id값이 최종 sub-graph에 포함되는 문제 해결

## 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

 
## 📝 작업 내용
- Initial Keyword 추가 시 필터링된 sub-graph를 참조하는 것이 아닌 원본 Agent 출력을 참조하는 문제 해결
- 최종 sub-graph return 이전에 존재하지 않는 Node를 참조하는 Edge가 있는지 확인하는 로직 추가

## 💬 리뷰 요구사항 or 추가 코멘트(선택)
> 리뷰어가 특별히 살펴봤으면 하는 부분이나 추가 코멘트가 있다면 작성해주세요
